### PR TITLE
Fix/material base color

### DIFF
--- a/Sources/GLTFSwift/GLTFLoader.swift
+++ b/Sources/GLTFSwift/GLTFLoader.swift
@@ -142,7 +142,7 @@ class GLTFLoader {
       }
 
       colors = try decompressedBuffers.colors.map {
-        try .from(data: $0, componentType: .float, normalize: false)
+        try .from(data: $0, componentType: .float, dataType: .vec3, normalize: false)
       }
 
       weights = try decompressedBuffers.weights.map {

--- a/Sources/GLTFSwift/GLTFSwift.swift
+++ b/Sources/GLTFSwift/GLTFSwift.swift
@@ -111,12 +111,16 @@ struct GLTFMesh: Decodable {
 
 // MARK: - Material
 struct GLTFMaterial: Decodable {
+  let name: String?
+  let doubleSided: Bool?
   let baseColorFactor: [Float]?
   let metallicFactor: Float?
   let roughnessFactor: Float?
 
   enum CodingKeys: String, CodingKey {
     case pbrMetallicRoughness
+    case name
+    case doubleSided
   }
 
   enum PBRMetallicRoughnessKeys: String, CodingKey {
@@ -137,6 +141,9 @@ struct GLTFMaterial: Decodable {
       self.metallicFactor = nil
       self.roughnessFactor = nil
     }
+
+    self.name = try container.decodeIfPresent(String.self, forKey: .name)
+    self.doubleSided = try container.decodeIfPresent(Bool.self, forKey: .doubleSided)
   }
 }
 

--- a/Sources/GLTFSwift/Public/GLTFAsset.swift
+++ b/Sources/GLTFSwift/Public/GLTFAsset.swift
@@ -2,7 +2,7 @@ import Foundation
 import simd
 
 public struct Material {
-  public let baseColor: simd_float4
+  public let baseColor: simd_float4?
   public let metallicFactor: Float
   public let roughnessFactor: Float
 
@@ -13,7 +13,7 @@ public struct Material {
   }
 
   init(material: GLTFMaterial) {
-    self.baseColor = .init(material.baseColorFactor ?? [1,1,1,1])
+    self.baseColor = material.baseColorFactor.map(simd_float4.init)
     self.metallicFactor = material.metallicFactor ?? 1.0
     self.roughnessFactor = material.roughnessFactor ?? 1.0
   }


### PR DESCRIPTION
Color data was corrupted because it was mapped as vec4 instead of vec3 when mapped from an encoded buffer.